### PR TITLE
Call the function with the same list of arguments

### DIFF
--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -22,6 +22,14 @@ Invoice.all = function (config, params, cb) {
   }
 };
 
+Invoice.all = function (config, params, cb) {
+  if (typeof params === 'string') {
+    return Invoice.all_customer.apply(Invoice, arguments);
+  } else {
+    return Invoice.all_any.apply(Invoice, arguments);
+  }
+};
+
 Invoice.destroy = Resource._method('DELETE', '/v1/invoices{/uuid}');
 
 Invoice.retrieve = Resource._method('GET', '/v1/invoices{/uuid}');

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -16,14 +16,6 @@ Invoice.all_any = Resource._method('GET', '/v1/invoices');
 
 Invoice.all = function (config, params, cb) {
   if (typeof params === 'string') {
-    return Invoice.all_customer(config, params, cb);
-  } else {
-    return Invoice.all_any(config, params, cb);
-  }
-};
-
-Invoice.all = function (config, params, cb) {
-  if (typeof params === 'string') {
     return Invoice.all_customer.apply(Invoice, arguments);
   } else {
     return Invoice.all_any.apply(Invoice, arguments);


### PR DESCRIPTION
Specifically providing the 3 arguments provides cb as undefined as a 3rd parameter, and the _method wrapper converts the "params" parameter into arg parameters instead of post body.

This came up because I use the promise version instead of the callback version

await Invoice.all({ stuff })

would return all the invoices, instead of the limiting i did.